### PR TITLE
build of navit ebuild broken due to change of README file name

### DIFF
--- a/sci-geosciences/navit/navit-9999-r1.ebuild
+++ b/sci-geosciences/navit/navit-9999-r1.ebuild
@@ -52,5 +52,5 @@ src_configure() {
 src_install () {
 	cmake-utils_src_install
 
-	dodoc AUTHORS ChangeLog README || die "dodoc failed"
+	dodoc AUTHORS ChangeLog README.md || die "dodoc failed"
 }


### PR DESCRIPTION
The navit project changed the README filename from README to README.md. As src_install expects a not existing README file it breaks. I corrected name of README file to recover the installation process.