### PR TITLE
[earlyoom] Fix `make` not producing systemd service file

### DIFF
--- a/sys-apps/earlyoom/earlyoom-1.0.ebuild
+++ b/sys-apps/earlyoom/earlyoom-1.0.ebuild
@@ -19,6 +19,7 @@ RDEPEND="${DEPEND}"
 
 src_compile() {
 	emake earlyoom
+	use systemd && emake earlyoom.service
 }
 
 src_install() {


### PR DESCRIPTION
Without  this line, emerge fails with `OSError: [Errno 2] No such file or directory: 'earlyoom.service'`