### PR TITLE
sys-apps/earlyoom: Minor fixes

### DIFF
--- a/sys-apps/earlyoom/earlyoom-1.2.ebuild
+++ b/sys-apps/earlyoom/earlyoom-1.2.ebuild
@@ -12,18 +12,24 @@ SRC_URI="https://github.com/rfjakob/earlyoom/archive/v$PV.tar.gz -> $P.tar.gz"
 LICENSE="MIT-with-advertising"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="+openrc systemd"
+IUSE="+openrc systemd docs"
 
-DEPEND=""
-RDEPEND="${DEPEND}"
+DEPEND="docs? ( app-text/pandoc )"
+RDEPEND=""
 
 src_compile() {
 	emake earlyoom
-	use systemd && emake earlyoom.service
+	use docs && emake earlyoom.1
+	use systemd && emake PREFIX=/usr earlyoom.service
 }
 
 src_install() {
 	dobin earlyoom
+	use docs && doman earlyoom.1
+
+	insinto /etc/default
+	newins earlyoom.default earlyoom
+
 	use openrc && doinitd "$FILESDIR/$PN"
 	use systemd && systemd_dounit earlyoom.service
 }


### PR DESCRIPTION
By default, the Systemd unit file contained:
```
ExecStart=/usr/local/bin/earlyoom $EARLYOOM_ARGS
```
which did not match the location it was installed to (`/usr/bin`).
This PR fixes this, as well as including the man page and default config file as well.

(I've kept the man page behind a USE flag as pandoc is a fairly heavy-weight dependency - happy to remove the flag if that's more to your preference.)