### PR TITLE
Add dv cleanup patch for gnunet-9999-r1.ebuild

### DIFF
--- a/net-p2p/gnunet/files/gnunet-9999-Drop-remaining-DV-stuff-from-POTFILES.in.patch
+++ b/net-p2p/gnunet/files/gnunet-9999-Drop-remaining-DV-stuff-from-POTFILES.in.patch
@@ -1,0 +1,28 @@
+From b65a51faec4988354bbcf087e0d71f6713b9a5b5 Mon Sep 17 00:00:00 2001
+From: Robin Kauffman <robink@creosotehill.org>
+Date: Tue, 12 Feb 2019 19:55:34 -0800
+Subject: [PATCH] Drop remaining DV stuff from POTFILES.in
+
+Looks like upstream forgot to fully flush it out.
+---
+ po/POTFILES.in | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/po/POTFILES.in b/po/POTFILES.in
+index fb1e0e25e..2f243d9eb 100644
+--- a/po/POTFILES.in
++++ b/po/POTFILES.in
+@@ -128,10 +128,6 @@ src/dns/gnunet-helper-dns.c
+ src/dns/gnunet-service-dns.c
+ src/dns/gnunet-zonewalk.c
+ src/dns/plugin_block_dns.c
+-src/dv/dv_api.c
+-src/dv/gnunet-dv.c
+-src/dv/gnunet-service-dv.c
+-src/dv/plugin_transport_dv.c
+ src/exit/gnunet-daemon-exit.c
+ src/exit/gnunet-helper-exit.c
+ src/exit/gnunet-helper-exit-windows.c
+-- 
+2.20.1
+

--- a/net-p2p/gnunet/gnunet-9999-r1.ebuild
+++ b/net-p2p/gnunet/gnunet-9999-r1.ebuild
@@ -56,6 +56,8 @@ DEPEND="
 	)
 "
 
+PATCHES=( "${FILESDIR}/${P}-Drop-remaining-DV-stuff-from-POTFILES.in.patch" )
+
 pkg_setup() {
 	enewgroup gnunetdns
 	enewuser  gnunet


### PR DESCRIPTION
Hiya-
    This is a (probably very) temporary fix that's nonetheless needed (a/o 2019-02-13 04:15Z, GNUNet commit a8d06e45c04df151594cf34ce7a17743465fa8db) to get the src_compile phase to finish up.  Have been toying with the idea of getting the ebuild ported to EAPI 7, but that's not in any way necessary and more just a bit of fussiness on my part.  Nonetheless, this PR just has the patch added.

        -Robin K.

Original commit message is below:

Upstream didn't drop dv/* from po/POTFILES.in, which causes the build to
fail when working on localization.  They'll fix this upstream in
relatively short order, so I don't anticipate this patch will be
necessary for very long.