### PR TITLE
monero-gui: add hw-wallet use for trezor

### DIFF
--- a/net-p2p/monero-gui/monero-gui-0.17.2.0.ebuild
+++ b/net-p2p/monero-gui/monero-gui-0.17.2.0.ebuild
@@ -12,7 +12,7 @@ EGIT_COMMIT="v${PV}"
 LICENSE="NEWLIB"
 SLOT="0"
 KEYWORDS="~x86 ~amd64"
-IUSE="qrcode smartcard unwind"
+IUSE="hw-wallet qrcode smartcard unwind"
 
 COMMON_DEPEND="net-p2p/monero:=
 	dev-db/lmdb:=
@@ -48,7 +48,7 @@ src_configure () {
 	local mycmakeargs=(
 		-DBUILD_SHARED_LIBS=OFF
 		-DMANUAL_SUBMODULES=ON
-		-DUSE_DEVICE_TREZOR=OFF
+		-DUSE_DEVICE_TREZOR=$(usex hw-wallet)
 	)
 	cmake_src_configure
 }


### PR DESCRIPTION
There is currently no way to use this ebuild with Trezor. CLI wallet [net-p2p/monero](https://github.com/gentoo-mirror/monero/blob/master/net-p2p/monero/metadata.xml#L14-L17) from monero overlay has a hw-wallet use flag which configures Trezor support, so I've added the analogous flag to the GUI wallet.